### PR TITLE
fix bug on tabs

### DIFF
--- a/shinyssd/inst/shiny/app.R
+++ b/shinyssd/inst/shiny/app.R
@@ -177,8 +177,8 @@ server <- function(input, output, session){
      lista <- data.frame(filtered()$sps_sc_name, filtered()$sps_group)
      colnames(lista) <- c("sps_sc_name", "sps_group")
      ul <- list %>%
-       group_by_(sps_sc_name, sps_group) %>%
-       summarise_()
+       dplyr::group_by(sps_sc_name, sps_group) %>%
+       dplyr::summarise()
      colnames(ul) <- c("sps_sc_name", "sps_group")
      ta <- merge(ul, ta, sort = FALSE, by.x = "sps_sc_name", by.y = "sps_sc_name" )
      colnames(ta) <- c("sps_sc_name", "sps_group", "values", "frac")
@@ -189,12 +189,12 @@ server <- function(input, output, session){
    visual <- reactive({
     visual <- tbl() %>%
       dplyr::filter(input$chem_name == chem_name) %>%
-      group_by_(sps_group, sps_sc_name, endpoint, chem_name) %>%
-      summarise_(n())
+      dplyr::group_by(sps_group, sps_sc_name, endpoint, chem_name) %>%
+      dplyr::summarise(n())
     colnames(visual)<-c("sps_group", "sps_sc_name", "endpoint", "chem_name", "n")
     vis <- visual %>%
-      group_by_(sps_group, endpoint) %>%
-      summarise_(n())
+      dplyr::group_by(sps_group, endpoint) %>%
+      dplyr::summarise(n())
     colnames(vis)<-c("sps_group", "endpoint", "n")
     vis$Y1 <- cut(vis$n, breaks = c(0, 8, 10, 30, Inf), right = FALSE)
     print(vis)

--- a/shinyssd/inst/shiny/app.R
+++ b/shinyssd/inst/shiny/app.R
@@ -168,13 +168,14 @@ server <- function(input, output, session){
 
   # When there are reported bioassays for the same species, the geometric mean is calculated 
   geom <- reactive({
-     ta <- as.data.frame(tapply(as.numeric(filtered()$values), filtered()$sps_sc_name, FUN = geoMean))
+     faux <- filtered()
+     ta <- as.data.frame(tapply(as.numeric(faux$values), faux$sps_sc_name, FUN = geoMean))
      ta <- tibble::rownames_to_column(ta, var = "rowname")
      colnames(ta) <- c("sps_sc_name", "values")
      ta <- ta[order(ta$values), ]
      ta$frac <- ppoints(ta$values, 0.5)
     
-     lista <- data.frame(filtered()$sps_sc_name, filtered()$sps_group)
+     lista <- data.frame(faux$sps_sc_name, faux$sps_group)
      colnames(lista) <- c("sps_sc_name", "sps_group")
      ul <- lista %>%
        dplyr::group_by(sps_sc_name, sps_group) %>%

--- a/shinyssd/inst/shiny/app.R
+++ b/shinyssd/inst/shiny/app.R
@@ -176,7 +176,7 @@ server <- function(input, output, session){
     
      lista <- data.frame(filtered()$sps_sc_name, filtered()$sps_group)
      colnames(lista) <- c("sps_sc_name", "sps_group")
-     ul <- list %>%
+     ul <- lista %>%
        dplyr::group_by(sps_sc_name, sps_group) %>%
        dplyr::summarise()
      colnames(ul) <- c("sps_sc_name", "sps_group")

--- a/shinyssd/inst/shiny/app.R
+++ b/shinyssd/inst/shiny/app.R
@@ -174,7 +174,7 @@ server <- function(input, output, session){
      ta <- ta[order(ta$values), ]
      ta$frac <- ppoints(ta$values, 0.5)
     
-  lista <- data.frame(filtered()$sps_sc_name, filtered()$sps_group)
+     lista <- data.frame(filtered()$sps_sc_name, filtered()$sps_group)
      colnames(lista) <- c("sps_sc_name", "sps_group")
      ul <- list %>%
        group_by_(sps_sc_name, sps_group) %>%


### PR DESCRIPTION
This pull request resolves  errors showed in the tabs: no applicable method for group_by_ applied to an object of class function.

![screenshot from 2018-12-20 15-28-46](https://user-images.githubusercontent.com/3030113/50304389-925d1c00-046e-11e9-9d39-1cba80f3cb0c.png)
![screenshot from 2018-12-20 12-03-37](https://user-images.githubusercontent.com/3030113/50304391-95580c80-046e-11e9-8b9d-beb089938387.png)

![screenshot from 2018-12-20 15-28-42](https://user-images.githubusercontent.com/3030113/50304376-8c673b00-046e-11e9-9429-3ff00b50c344.png)


The problem was how group_by and summarise functions where called. By changing group_by_ by dplyr::group_by and summarise_ by dplyr::summarise part of the problem was solved.

Another bug was in function geom.

With the bugs solved, content is displayed on the tabs.